### PR TITLE
include <stdexcept>

### DIFF
--- a/include/cache.hpp
+++ b/include/cache.hpp
@@ -9,6 +9,7 @@
 #include <mutex>
 #include <optional>
 #include <shared_mutex>
+#include <stdexcept>
 #include <unordered_map>
 
 namespace caches


### PR DESCRIPTION
Fix `error: ‘range_error’ is not a member of ‘std’`.